### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/latekpro/ghas-jotb2025/security/code-scanning/5](https://github.com/latekpro/ghas-jotb2025/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled by removing the `http.csrf().disable()` call. If there are specific endpoints or use cases where CSRF protection is not required, those can be explicitly excluded using Spring Security's configuration options. This ensures that the application is protected against CSRF attacks while maintaining flexibility for specific scenarios.

The changes will involve:
1. Removing the `http.csrf().disable()` call in the `configure(HttpSecurity http)` method.
2. Optionally, if there are endpoints that do not require CSRF protection, configuring Spring Security to ignore CSRF for those specific endpoints.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
